### PR TITLE
tweak readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ $ npm install level levelgraph levelgraph-jsonld --save
 ```
 Then in your code:
 ```javascript
-var levelup = require("levelup"),
-    yourDB = levelup("./yourdb"),
+var level      = require('level'),
+    yourDB     = level('./yourdb'),
     levelgraph = require('levelgraph'),
-    levelgraphJSONLD = require('levelgraph-jsonld'),
-    db = levelgraphJSONLD(levelgraph(yourDB));
+    jsonld     = require('levelgraph-jsonld'),
+    db         = jsonld(levelgraph(yourDB));
 ```
 
 At the moment it requires node v0.10.x, but the port to node v0.8.x
@@ -62,15 +62,15 @@ It will also install its dependency levelgraph! Now you can simply:
 We assume in following examples that you created database as explained
 above!
 ```js
-var levelup = require("levelup"),
-    yourDB = levelup("./yourdb"),
-    db = levelgraphJSONLD(levelgraph(yourDB));
+var level  = require('level'),
+    yourDB = level('./yourdb'),
+    db     = levelgraphJSONLD(levelgraph(yourDB));
 ```
 
 `'base'` can also be specified when you create the db:
 ```javascript
-var levelup    = require("levelup"),
-    yourDB     = levelup("./yourdb"),
+var level      = require('level'),
+    yourDB     = level('./yourdb'),
     levelgraph = require('levelgraph'),
     jsonld     = require('levelgraph-jsonld'),
     opts       = { base: 'http://matteocollina.com/base' },


### PR DESCRIPTION
* use `level` in examples rather than `levelup` for the following reasons:
  * the install instructions says to install level
  * it's the recommended way of using `LevelDB`
  * `levelup` api has changed and accepts an `abstract-leveldown` compliant store as first argument, i.e. no longer a string
* single quotes everywhere
* align variables (or don't align, I just picked one of them to be consistent)