### PR TITLE
levelgraph update from 2.0.0 to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "uuid": "^3.0.1"
   },
   "peerDependencies": {
-    "levelgraph": "^2.0.0"
+    "levelgraph": "^3.0.0"
   },
   "devDependencies": {
     "browserify": "^14.0.0",


### PR DESCRIPTION
db.get Legacy range options ("start" and "end") have been removed

see https://github.com/scenaristeur/os/issues/1 for error message